### PR TITLE
Add deduplication

### DIFF
--- a/transform/models/clean/_clean_sales_line_items.yml
+++ b/transform/models/clean/_clean_sales_line_items.yml
@@ -3,7 +3,7 @@ version: 2
 models:
 
   - name: clean_sales_line_items
-    description: Clean, valid, type-casted Amazon Sale line items.
+    description: Clean, valid, deduplicated, type-casted Amazon Sale line items.
     columns:
       - name: id
         description: (Surrogate) primary key for this table
@@ -21,6 +21,7 @@ models:
         description: Natural Key. Unique identifier for the order of the sale, as coming from the source system. An order can include many items.
         data_type: string
         tests:
+          - unique
           - not_null
       - name: date
         description: '{{doc("_doc_raw__amazon_sale_report__date")}}'

--- a/transform/models/clean/_clean_sales_line_items.yml
+++ b/transform/models/clean/_clean_sales_line_items.yml
@@ -3,7 +3,7 @@ version: 2
 models:
 
   - name: clean_sales_line_items
-    description: Clean, valid, deduplicated, type-casted Amazon Sale line items.
+    description: Clean, valid, deduplicated Amazon Sale line items.
     columns:
       - name: id
         description: (Surrogate) primary key for this table

--- a/transform/models/clean/clean_sales_line_items.sql
+++ b/transform/models/clean/clean_sales_line_items.sql
@@ -2,33 +2,95 @@ WITH cte_staging_sales_line_items AS (
 
 	SELECT * FROM {{ ref('staging_sales_line_items') }}
 
+),
+
+cte_typecasted_sales_line_items AS (
+	SELECT
+		line_item_code::VARCHAR AS line_item_code,
+		order_code::VARCHAR AS order_code,
+		STRPTIME(date, '%m-%d-%y')::DATE AS date,
+		status::VARCHAR AS status,
+		fulfillment::VARCHAR AS fulfillment,
+		sales_channel::VARCHAR AS sales_channel,
+		ship_service_level::VARCHAR AS ship_service_level,
+		style::VARCHAR AS style,
+		sku::VARCHAR AS sku,
+		category::VARCHAR AS category,
+		size::VARCHAR AS size,
+		asin::VARCHAR AS asin,
+		courier_status::VARCHAR AS courier_status,
+		quantity::BIGINT AS quantity,
+		currency::VARCHAR AS currency,
+		amount::DECIMAL(19, 4) AS amount,
+		ship_city::VARCHAR AS ship_city,
+		ship_state::VARCHAR AS ship_state,
+		ship_postal_code::VARCHAR AS ship_postal_code,
+		ship_country::VARCHAR AS ship_country,
+		promotion_ids::VARCHAR AS promotion_ids,
+		b2b::BOOLEAN AS b2b,
+		fulfilled_by::VARCHAR AS fulfilled_by,
+		unnamed_22::BOOLEAN AS unnamed_22
+	FROM
+		cte_staging_sales_line_items
+),
+
+cte_unique_sales_line_items AS (
+	SELECT
+		ROW_NUMBER() OVER (PARTITION BY order_code ORDER BY date DESC, line_item_code DESC) AS row_num,
+		line_item_code,
+		order_code,
+		date,
+		status,
+		fulfillment,
+		sales_channel,
+		ship_service_level,
+		style,
+		sku,
+		category,
+		size,
+		asin,
+		courier_status,
+		quantity,
+		currency,
+		amount,
+		ship_city,
+		ship_state,
+		ship_postal_code,
+		ship_country,
+		promotion_ids,
+		b2b,
+		fulfilled_by,
+		unnamed_22
+	FROM
+		cte_typecasted_sales_line_items
+	QUALIFY row_num = 1
 )
 
 SELECT
 	{{ dbt_utils.generate_surrogate_key(['line_item_code']) }}::VARCHAR AS id,
-	line_item_code::VARCHAR AS line_item_code,
-	order_code::VARCHAR AS order_code,
-	STRPTIME(date, '%m-%d-%y')::DATE AS date,
-	status::VARCHAR AS status,
-	fulfillment::VARCHAR AS fulfillment,
-	sales_channel::VARCHAR AS sales_channel,
-	ship_service_level::VARCHAR AS ship_service_level,
-	style::VARCHAR AS style,
-	sku::VARCHAR AS sku,
-	category::VARCHAR AS category,
-	size::VARCHAR AS size,
-	asin::VARCHAR AS asin,
-	courier_status::VARCHAR AS courier_status,
-	quantity::BIGINT AS quantity,
-	currency::VARCHAR AS currency,
-	amount::DECIMAL(19, 4) AS amount,
-	ship_city::VARCHAR AS ship_city,
-	ship_state::VARCHAR AS ship_state,
-	ship_postal_code::VARCHAR AS ship_postal_code,
-	ship_country::VARCHAR AS ship_country,
-	promotion_ids::VARCHAR AS promotion_ids,
-	b2b::BOOLEAN AS b2b,
-	fulfilled_by::VARCHAR AS fulfilled_by,
-	unnamed_22::BOOLEAN AS unnamed_22
+	line_item_code,
+	order_code,
+	date,
+	status,
+	fulfillment,
+	sales_channel,
+	ship_service_level,
+	style,
+	sku,
+	category,
+	size,
+	asin,
+	courier_status,
+	quantity,
+	currency,
+	amount,
+	ship_city,
+	ship_state,
+	ship_postal_code,
+	ship_country,
+	promotion_ids,
+	b2b,
+	fulfilled_by,
+	unnamed_22
 FROM
-	cte_staging_sales_line_items
+	cte_unique_sales_line_items

--- a/transform/models/staging/_staging_sales_line_items.yml
+++ b/transform/models/staging/_staging_sales_line_items.yml
@@ -3,7 +3,7 @@ version: 2
 models:
 
   - name: staging_sales_line_items
-    description: Staging table for Amazon Sales Report data
+    description: Staging table for Amazon Sales Report data. Applies typecasting and standard naming convention to raw data.
     columns:
       - name: id
         description: |


### PR DESCRIPTION
The original dataset contains duplicates, which we are not fixing yet. This PR removes duplicates, leaving the duplicate warning in the staging area for auditing/debugging purposes.